### PR TITLE
fix stringify value with % char issue

### DIFF
--- a/colorize.go
+++ b/colorize.go
@@ -116,7 +116,20 @@ func (c *Colorize) TogglePlain() {
 
 // Paint returns colored string
 func (c Colorize) Paint(args ...interface{}) string {
-	c.Values = args
+	c.Values = make([]interface{}, len(args))
+	for i, arg := range args {
+		switch arg.(type) {
+		case string:
+			c.Values[i] = strings.Replace(arg.(string), "%", "%%", -1)
+
+		case []byte:
+			c.Values[i] = strings.Replace(string(arg.([]byte)), "%", "%%", -1)
+
+		default:
+			c.Values[i] = arg
+
+		}
+	}
 
 	return fmt.Sprint(c)
 }

--- a/colorize_test.go
+++ b/colorize_test.go
@@ -16,6 +16,7 @@ func Test_New(t *testing.T) {
 
 func Test_Paint(t *testing.T) {
 	var colorize Colorize
+
 	testCases := map[Color]string{
 		ColorRed:     "\x1b[0;31mColorful text!\x1b[0m",
 		ColorGreen:   "\x1b[0;32mColorful text!\x1b[0m",
@@ -32,6 +33,11 @@ func Test_Paint(t *testing.T) {
 
 		assert.Equal(t, expected, colorize.Paint("Colorful text!"))
 	}
+
+	// should work with percent symbal
+	colorize.SetFgColor(ColorRed)
+	assert.Equal(t, "\x1b[0;31mColorful 50%!\x1b[0m", colorize.Paint("Colorful 50%!"))
+	assert.Equal(t, "\x1b[0;31mColorful 50%!\x1b[0m", colorize.Paint([]byte("Colorful 50%!")))
 }
 
 func Test_SetPlain(t *testing.T) {


### PR DESCRIPTION
Why:

  * fmt.Sprint() try to re-format painted values with % char

How:

  * replace all % with %%, avoiding fmt re-formation